### PR TITLE
Add support for GKE auth plugin

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: windows-latest
     outputs:
       VERSION: ${{ steps.step1.outputs.VERSION }}
+      GCLOUD_CLI_VERSION: ${{ steps.step1.outputs.GCLOUD_CLI_VERSION }}
       CONTINUE: ${{ steps.step1.outputs.Continue }}
     steps:    
     - uses: actions/checkout@v3

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -19,6 +19,45 @@ jobs:
     - id: step1
       name: Compare latest version with container
       run: |
+        Write-Output "Getting GCLOUD CLI version (needed for gke-auth-plugin)"
+        $googleCloudSdkInfo = Invoke-RestMethod "https://registry.hub.docker.com/v2/repositories/google/cloud-sdk/tags?page=1"
+        $otherImages = $googleCloudSdkInfo.results | Where-Object { $_.name -ine "latest" }
+        $latestTag = $googleCloudSdkInfo.results | Where-Object { $_.name -ieq "latest" }
+        
+        if($null -eq $latestTag)  {
+            throw "Couldnt find latest tag for Google Cloud SDK version from DockerHub"
+        }
+        
+        $latestTagImage = $latestTag.images | Where-Object {$_.os -ieq "linux" -and $_.architecture -ieq "amd64" -and $_.status -ieq "active"} | Select-Object -First 1
+        if($null -eq $latestTagImage)  {
+            throw "Couldnt find latest tag image for Google Cloud SDK version for linux/amd64"
+        }
+        $latestDigest = $latestTagImage.digest
+        Write-Output "Found latest digest: $latestDigest"
+
+        $GCLOUD_CLI_VERSION = ""
+        foreach($result in $otherImages) {
+            $matchingImageDigest = $result.images | Where-Object {$_.os -ieq "linux" -and $_.architecture -ieq "amd64" -and $_.status -ieq "active" -and $_.digest -ieq $latestDigest } | Select-Object -First 1
+            if($null -eq $matchingImageDigest) {
+                continue;
+            }
+            else {
+                $version = $result.name
+                Write-Output "Found version '$version' that matches digest: $latestDigest"
+                $versionSplit = $version.Split(".")
+                $GCLOUD_CLI_VERSION = "$($versionSplit[0]).$($versionSplit[1]).$($versionSplit[2])"
+                break;
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($GCLOUD_CLI_VERSION)) {
+            throw "No GCLOUD CLI version with digest $latestDigest found"
+        }
+        else {
+            echo "GCLOUD_CLI_VERSION=$GCLOUD_CLI_VERSION" >> $env:GITHUB_OUTPUT
+        }
+
+        Write-Output "Getting Kubectl version"
         $chocoInformationRaw = choco info kubernetes-cli --limitoutput
         $version = ($chocoInformationRaw.Split("|"))[1]
         $versionSplit = $version.Split(".")
@@ -106,7 +145,8 @@ jobs:
     - name: Build the Docker image
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
-      run: docker build ./windows-2019 --tag octopuslabs/k8s-workertools:${env:VERSION_NUMBER}-windows.2019 --tag octopuslabs/k8s-workertools:latest-windows.2019
+        GCLOUD_CLI_VERSION: ${{ needs.get-version-number.outputs.GCLOUD_CLI_VERSION }}
+      run: docker build ./windows-2019 --build-arg GCLOUD_CLI_VERSION=${env:GCLOUD_CLI_VERSION} --tag octopuslabs/k8s-workertools:${env:VERSION_NUMBER}-windows.2019 --tag octopuslabs/k8s-workertools:latest-windows.2019
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
     - name: Push the version image

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains images that contain the tooling necessary to to use the
 - Kubectl
 - Helm
 - AWS IAM Authenticator
+- Google's GKE Cloud Auth Plugin
 
 There are three images built in this repo:
 

--- a/ubuntu-1804/Dockerfile
+++ b/ubuntu-1804/Dockerfile
@@ -8,6 +8,9 @@ RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packa
     echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update && apt-get install -y kubectl
 
+# Install git
+RUN apt-get update && apt-get install -y git
+
 # Get latest Helm v3
 RUN wget --quiet -O - https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 

--- a/ubuntu-1804/Dockerfile
+++ b/ubuntu-1804/Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND noninteractive
 # Get kubectl
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
 RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg  && \
-    echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list && \
+    echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update && apt-get install -y kubectl
 
 # Get latest Helm v3
@@ -23,8 +23,8 @@ RUN curl --silent --location https://amazon-eks.s3.us-west-2.amazonaws.com/1.19.
 
 # Get gke-gcloud-auth-plugin (reqd for kubectl 1.26+)
 # See https://github.com/OctopusDeploy/Issues/issues/7621 for more info
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     apt-get update && apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
 # Get the Istio CLI

--- a/ubuntu-1804/Dockerfile
+++ b/ubuntu-1804/Dockerfile
@@ -2,9 +2,10 @@ FROM octopuslabs/workertools:latest-ubuntu.1804
 
 ARG DEBIAN_FRONTEND noninteractive
 
-# Get Kubernetes
-RUN wget --quiet -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -  && \
-    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
+# Get kubectl
+# https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg  && \
+    echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update && apt-get install -y kubectl
 
 # Get latest Helm v3
@@ -19,6 +20,12 @@ RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/late
 # https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html
 RUN curl --silent --location https://amazon-eks.s3.us-west-2.amazonaws.com/1.19.6/2021-01-05/bin/linux/amd64/aws-iam-authenticator -o /usr/local/bin/aws-iam-authenticator && \
     chmod +x /usr/local/bin/aws-iam-authenticator
+
+# Get gke-gcloud-auth-plugin (reqd for kubectl 1.26+)
+# See https://github.com/OctopusDeploy/Issues/issues/7621 for more info
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    apt-get update && apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
 # Get the Istio CLI
 # https://istio.io/docs/ops/diagnostic-tools/istioctl/

--- a/ubuntu-2004/Dockerfile
+++ b/ubuntu-2004/Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND noninteractive
 # Get kubectl
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
 RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg  && \
-    echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list && \
+    echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update && apt-get install -y kubectl
 
 # Get latest Helm v3
@@ -23,8 +23,8 @@ RUN curl --silent --location https://amazon-eks.s3.us-west-2.amazonaws.com/1.19.
 
 # Get gke-gcloud-auth-plugin (reqd for kubectl 1.26+)
 # See https://github.com/OctopusDeploy/Issues/issues/7621 for more info
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     apt-get update && apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
 # Get the Istio CLI

--- a/ubuntu-2004/Dockerfile
+++ b/ubuntu-2004/Dockerfile
@@ -2,9 +2,10 @@ FROM octopuslabs/workertools:latest-ubuntu.2004
 
 ARG DEBIAN_FRONTEND noninteractive
 
-# Get Kubernetes
-RUN wget --quiet -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -  && \
-    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
+# Get kubectl
+# https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg  && \
+    echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update && apt-get install -y kubectl
 
 # Get latest Helm v3
@@ -19,6 +20,12 @@ RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/late
 # https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html
 RUN curl --silent --location https://amazon-eks.s3.us-west-2.amazonaws.com/1.19.6/2021-01-05/bin/linux/amd64/aws-iam-authenticator -o /usr/local/bin/aws-iam-authenticator && \
     chmod +x /usr/local/bin/aws-iam-authenticator
+
+# Get gke-gcloud-auth-plugin (reqd for kubectl 1.26+)
+# See https://github.com/OctopusDeploy/Issues/issues/7621 for more info
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    apt-get update && apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
 # Get the Istio CLI
 # https://istio.io/docs/ops/diagnostic-tools/istioctl/

--- a/ubuntu-2004/Dockerfile
+++ b/ubuntu-2004/Dockerfile
@@ -8,6 +8,9 @@ RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packa
     echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update && apt-get install -y kubectl
 
+# Install git
+RUN apt-get update && apt-get install -y git 
+
 # Get latest Helm v3
 RUN wget --quiet -O - https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 

--- a/windows-2019/Dockerfile
+++ b/windows-2019/Dockerfile
@@ -3,6 +3,9 @@
 FROM octopuslabs/workertools:latest-windows.2019
 SHELL ["powershell", "-Command"]
 
+# gcloud cli needed for gke auth plugin
+ARG GCLOUD_CLI_VERSION=410.0.0
+
 RUN choco install kubernetes-cli -y --no-progress
 
 RUN choco install -y kubernetes-helm --no-progress
@@ -11,8 +14,29 @@ RUN choco install eksctl -y --no-progress
 
 RUN choco install aws-iam-authenticator -y --no-progress
 
-# # Install Azure CLI
+# Install Azure CLI
 RUN choco install azure-cli -y --no-progress
 
 RUN Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force; `
     Install-Module -Force -Name Az -AllowClobber -Scope AllUsers
+
+# Install gcloud (required for gke-auth-plugin)
+RUN $GCLOUD_VERSION = $env:GCLOUD_CLI_VERSION; `
+    Write-Host "GCLOUD_VERSION: ${env:GCLOUD_CLI_VERSION}"; `
+    Write-Host "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${env:GCLOUD_CLI_VERSION}-windows-x86_64.zip"; `
+    Invoke-WebRequest "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${env:GCLOUD_CLI_VERSION}-windows-x86_64.zip" -OutFile google-cloud-sdk-$env:GCLOUD_CLI_VERSION-windows-x86_64.zip; `
+    & '.\Program Files\7-Zip\7z.exe' x .\google-cloud-sdk-$env:GCLOUD_CLI_VERSION-windows-x86_64.zip; `
+    .\google-cloud-sdk\install.bat --quiet; `
+    rm .\google-cloud-sdk-$env:GCLOUD_CLI_VERSION-windows-x86_64.zip
+
+# Update Path
+RUN $old = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name path).path; `
+    Write-Host $old; `
+    $gcloudPath = ';C:\google-cloud-sdk\bin'; `    
+    $new = $old + $gcloudPath; `
+    Write-Host $new; `
+    Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name path -Value $new; `
+    refreshenv
+
+# Install GKE Auth plugin using GCloud
+RUN gcloud components install gke-gcloud-auth-plugin

--- a/windows-2019/Dockerfile
+++ b/windows-2019/Dockerfile
@@ -38,5 +38,9 @@ RUN $old = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentC
     Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name path -Value $new; `
     refreshenv
 
-# Install GKE Auth plugin using GCloud
-RUN gcloud components install gke-gcloud-auth-plugin --quiet
+# Install gke-gcloud-auth-plugin (gcloud cli doesnt make this easy)
+RUN Write-Host "Installing gke-gcloud-auth-plugin"; ` 
+    $env:CLOUDSDK_PYTHON = (& gcloud components copy-bundled-python); `
+    Write-Host "GCLOUDSDK_PYTHON path: ${env:CLOUDSDK_PYTHON}"; `
+    $env:GCloud_output = (gcloud components install gke-gcloud-auth-plugin --quiet 2>&1); `
+    if(-not [string]::IsNullOrWhiteSpace($env:GCloud_output)) { Write-Host $($env:GCloud_output -Replace "System.Management.Automation.RemoteException", ""); }

--- a/windows-2019/Dockerfile
+++ b/windows-2019/Dockerfile
@@ -39,4 +39,4 @@ RUN $old = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentC
     refreshenv
 
 # Install GKE Auth plugin using GCloud
-RUN gcloud components install gke-gcloud-auth-plugin
+RUN gcloud components install gke-gcloud-auth-plugin --quiet

--- a/windows-2019/Dockerfile
+++ b/windows-2019/Dockerfile
@@ -43,4 +43,4 @@ RUN Write-Host "Installing gke-gcloud-auth-plugin"; `
     $env:CLOUDSDK_PYTHON = (& gcloud components copy-bundled-python); `
     Write-Host "GCLOUDSDK_PYTHON path: ${env:CLOUDSDK_PYTHON}"; `
     $env:GCloud_output = (gcloud components install gke-gcloud-auth-plugin --quiet 2>&1); `
-    if(-not [string]::IsNullOrWhiteSpace($env:GCloud_output)) { Write-Host $($env:GCloud_output -Replace "System.Management.Automation.RemoteException", ""); }
+    if(-not [string]::IsNullOrWhiteSpace($env:GCloud_output)) { Write-Host "${env:GCloud_output}"; }


### PR DESCRIPTION
This PR adds support for the `gke-gcloud-auth-plugin`, which is required for kubectl v `1.26`+ 

See https://github.com/OctopusDeploy/Issues/issues/7621 for more info or the [GKE blog post](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke)

Also, the windows build is horrific. Google themselves recommend the following for installing the plugin (from the above post):

> Run the following command:
> 
> ```
> gcloud components install gke-gcloud-auth-plugin
> ```
> Note: gcloud is the recommended way to install the binary on Windows and OS X

Except in a non-interactive mode like a docker image, you can't **easily** run the `gcloud` cli to install a plugin. You have to copy the bundled python to a temp directory and run it from there.

As a result, the windows build also now needs the google cloud cli (`gcloud`) installed just to add the `gke-gcloud-auth-plugin` binary. :upside_down_face: 