### PR TITLE
Add kubelogin

### DIFF
--- a/ubuntu-2004/Dockerfile
+++ b/ubuntu-2004/Dockerfile
@@ -14,6 +14,13 @@ RUN apt-get update && apt-get install -y git
 # Get latest Helm v3
 RUN wget --quiet -O - https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
+# Get Kubelogin
+RUN wget --quiet https://github.com/Azure/kubelogin/releases/latest/download/kubelogin-linux-amd64.zip && \
+    unzip kubelogin-linux-amd64.zip -d kubelogin-linux-amd64 && \
+    mv kubelogin-linux-amd64/bin/linux_amd64/kubelogin /usr/local/bin && \
+    rm -rf kubelogin-linux-amd64 && \
+    rm kubelogin-linux-amd64.zip
+
 # Get EKS CLI
 # https://github.com/weaveworks/eksctl
 RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && \

--- a/ubuntu-2204/Dockerfile
+++ b/ubuntu-2204/Dockerfile
@@ -14,6 +14,13 @@ RUN apt-get update && apt-get install -y git
 # Get latest Helm v3
 RUN wget --quiet -O - https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
+# Get Kubelogin
+RUN wget --quiet https://github.com/Azure/kubelogin/releases/latest/download/kubelogin-linux-amd64.zip && \
+    unzip kubelogin-linux-amd64.zip -d kubelogin-linux-amd64 && \
+    mv kubelogin-linux-amd64/bin/linux_amd64/kubelogin /usr/local/bin && \
+    rm -rf kubelogin-linux-amd64 && \
+    rm kubelogin-linux-amd64.zip
+    
 # Get EKS CLI
 # https://github.com/weaveworks/eksctl
 RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && \

--- a/windows-2019/Dockerfile
+++ b/windows-2019/Dockerfile
@@ -10,6 +10,9 @@ RUN choco install kubernetes-cli -y --no-progress
 
 RUN choco install -y kubernetes-helm --no-progress
 
+# Get Kubelogin
+RUN choco install azure-kubelogin --no-progress -y
+
 RUN choco install eksctl -y --no-progress
 
 RUN choco install awscli -y --no-progress


### PR DESCRIPTION
I noticed we added kubelogin to workertools and it is missing on this image.
https://github.com/OctopusDeploy/WorkerTools/pull/65